### PR TITLE
Fix depth sensor issue when building

### DIFF
--- a/Runtime/Tx/DepthCameraTx.cs
+++ b/Runtime/Tx/DepthCameraTx.cs
@@ -19,6 +19,7 @@ public class DepthCameraTx : ProBridgeTxStamped<CompressedImage>
     public int textureHeight = 1024;
     public RawImage _rawImage;
     [Range(1, 100)] public int CompressionQuality = 90;
+    public Shader depthShader;
 
 
     private DepthCameraSensor _cameraSensor;
@@ -29,6 +30,7 @@ public class DepthCameraTx : ProBridgeTxStamped<CompressedImage>
     protected override void AfterEnable()
     {
         _cameraSensor = renderCamera.gameObject.AddComponent<DepthCameraSensor>();
+        _cameraSensor.mat = new Material(depthShader);
         _cameraSensor._camera = renderCamera;
         _cameraSensor.onSensorUpdated += OnSensorUpdated;
         _cameraSensor._minRange = _minRange;

--- a/Runtime/Tx/DepthCameraTx.cs.meta
+++ b/Runtime/Tx/DepthCameraTx.cs.meta
@@ -1,3 +1,15 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: d5bef5b061084775bddcb18e65f4b81d
-timeCreated: 1729508148
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences:
+  - host: {instanceID: 0}
+  - renderCamera: {instanceID: 0}
+  - _rawImage: {instanceID: 0}
+  - depthShader: {fileID: 4800000, guid: 0137d279ce9087e4dba1b98935f75aea, type: 3}
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Utils/UnitySensors/Scripts/Sensors/Camera/DepthCamera/DepthCameraSensor.cs
+++ b/Runtime/Utils/UnitySensors/Scripts/Sensors/Camera/DepthCamera/DepthCameraSensor.cs
@@ -7,6 +7,7 @@ using UnityEngine.Rendering;
 using Unity.Collections;
 using Unity.Jobs;
 using Unity.Mathematics;
+using UnityEngine.Serialization;
 using UnityEngine.UI;
 using UnitySensors.Data.PointCloud;
 using UnitySensors.Interface.Sensor;
@@ -31,7 +32,7 @@ namespace UnitySensors.Sensor.Camera
         private RenderTexture _rt = null;
         private Texture2D _texture;
 
-        private Material _mat;
+        public Material mat;
 
         private JobHandle _jobHandle;
 
@@ -63,9 +64,8 @@ namespace UnitySensors.Sensor.Camera
 
             _texture = new Texture2D(_resolution.x, _resolution.y, TextureFormat.RGBAFloat, false);
 
-            _mat = new Material(Shader.Find("UnitySensors/Color2Depth"));
             float f = m_camera.farClipPlane;
-            _mat.SetFloat("_F", f);
+            mat.SetFloat("_F", f);
 
             SetupDirections();
             SetupJob();
@@ -177,7 +177,7 @@ namespace UnitySensors.Sensor.Camera
 
         private void OnRenderImage(RenderTexture source, RenderTexture dest)
         {
-            Graphics.Blit(source, dest, _mat);
+            Graphics.Blit(source, dest, mat);
         }
     }
 }

--- a/Runtime/Utils/UnitySensors/Scripts/Sensors/Camera/DepthCamera/DepthCameraSensor.cs.meta
+++ b/Runtime/Utils/UnitySensors/Scripts/Sensors/Camera/DepthCamera/DepthCameraSensor.cs.meta
@@ -3,7 +3,9 @@ guid: cf70f25101c5d9f40a32e2e35f74d1e9
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
-  defaultReferences: []
+  defaultReferences:
+  - _camera: {instanceID: 0}
+  - _shader: {fileID: 4800000, guid: 0137d279ce9087e4dba1b98935f75aea, type: 3}
   executionOrder: 0
   icon: {instanceID: 0}
   userData: 


### PR DESCRIPTION
So there was an issue when building sims with depth sensor when the the shader would not be loaded to the build breaking the depth sensor. So to fix that the reference to the shader was added as a serializable field in the publisher which insures it gets included in the build.