### PR TITLE
Cameras Memory Leaks

### DIFF
--- a/Runtime/Tx/DepthCameraTx.cs
+++ b/Runtime/Tx/DepthCameraTx.cs
@@ -43,6 +43,11 @@ public class DepthCameraTx : ProBridgeTxStamped<CompressedImage>
         _cameraSensor.Init();
     }
 
+    protected override void AfterDisable()
+    {
+        _cameraSensor.DisposeSensor();
+    }
+
     private void OnSensorUpdated()
     {
         sensorReady = true;

--- a/Runtime/Utils/UnitySensors/Scripts/Sensors/Camera/DepthCamera/DepthCameraSensor.cs
+++ b/Runtime/Utils/UnitySensors/Scripts/Sensors/Camera/DepthCamera/DepthCameraSensor.cs
@@ -168,16 +168,25 @@ namespace UnitySensors.Sensor.Camera
 
         protected override void OnSensorDestroy()
         {
-            _jobHandle.Complete();
-            _pointCloud.Dispose();
-            _noises.Dispose();
-            _directions.Dispose();
-            _rt.Release();
+            // _jobHandle.Complete();
+            // _pointCloud.Dispose();
+            // _noises.Dispose();
+            // _directions.Dispose();
+            // _rt.Release();
         }
 
         private void OnRenderImage(RenderTexture source, RenderTexture dest)
         {
             Graphics.Blit(source, dest, mat);
+        }
+
+        public void DisposeSensor()
+        {
+            _jobHandle.Complete();
+            _pointCloud.Dispose();
+            _noises.Dispose();
+            _directions.Dispose();
+            _rt.Release();
         }
     }
 }


### PR DESCRIPTION
Compressed images: There was a memory leak due to AsyncGPUReadback still triggering callbacks after the object was disposed.

Depth images: The built-in Unity sensor only disposes on OnDestroy(). Disabling and re-enabling the camera caused reinitialization without proper cleanup, leading to memory issues.