### PR TITLE
Refactor improve depth cam perf

### DIFF
--- a/Runtime/Tx/DepthCameraTx.cs
+++ b/Runtime/Tx/DepthCameraTx.cs
@@ -49,6 +49,7 @@ public class DepthCameraTx : ProBridgeTxStamped<CompressedImage>
         _cameraSensor._frequency_inv = sendRate;
         _cameraSensor._resolution.x = textureWidth;
         _cameraSensor._resolution.y = textureHeight;
+        _cameraSensor.getPointCloud = getPointCloud;
         _cameraSensor.Init();
     }
 

--- a/Runtime/Tx/DepthCameraTx.cs
+++ b/Runtime/Tx/DepthCameraTx.cs
@@ -21,7 +21,12 @@ public class DepthCameraTx : ProBridgeTxStamped<CompressedImage>
     public RawImage _rawImage;
     [Range(1, 100)] public int CompressionQuality = 90;
     public Shader depthShader;
+    public bool getPointCloud = false;
 
+    public PointCloud<PointXYZ> pointCloud
+    {
+        get => _cameraSensor.pointCloud;
+    }
 
     private DepthCameraSensor _cameraSensor;
     private bool sensorReady = false;

--- a/Runtime/Tx/DepthCameraTx.cs
+++ b/Runtime/Tx/DepthCameraTx.cs
@@ -1,10 +1,11 @@
 ﻿using System;
-using System.Threading;
 using ProBridge.Tx;
 using sensor_msgs.msg;
 using TurboJpegWrapper;
+using Unity.Collections;
 using UnityEngine;
 using UnityEngine.UI;
+using UnitySensors.Data.PointCloud;
 using UnitySensors.Sensor.Camera;
 
 [AddComponentMenu("ProBridge/Tx/sensor_msgs/Depth Camera")]
@@ -23,12 +24,15 @@ public class DepthCameraTx : ProBridgeTxStamped<CompressedImage>
 
 
     private DepthCameraSensor _cameraSensor;
-
     private bool sensorReady = false;
 
+    // Reuse the compressor to avoid per-frame allocations.
+    private TJCompressor _compressor;
 
     protected override void AfterEnable()
     {
+        _compressor = new TJCompressor();
+
         _cameraSensor = renderCamera.gameObject.AddComponent<DepthCameraSensor>();
         _cameraSensor.mat = new Material(depthShader);
         _cameraSensor._camera = renderCamera;
@@ -45,7 +49,14 @@ public class DepthCameraTx : ProBridgeTxStamped<CompressedImage>
 
     protected override void AfterDisable()
     {
-        _cameraSensor.DisposeSensor();
+        if (_cameraSensor != null)
+            _cameraSensor.DisposeSensor();
+
+        if (_compressor != null)
+        {
+            _compressor.Dispose();
+            _compressor = null;
+        }
     }
 
     private void OnSensorUpdated()
@@ -56,17 +67,31 @@ public class DepthCameraTx : ProBridgeTxStamped<CompressedImage>
     protected override ProBridge.ProBridge.Msg GetMsg(TimeSpan ts)
     {
         if (!sensorReady)
-        {
             throw new Exception("Sensor is not ready");
-        }
+
+        var tex = _cameraSensor.texture0;
+        if (tex == null)
+            throw new Exception("Depth sensor texture is not a Texture2D.");
 
         if (_rawImage != null)
-            _rawImage.texture = _cameraSensor.texture0;
+            _rawImage.texture = tex;
 
         sensorReady = false;
 
+        NativeArray<byte> raw = tex.GetRawTextureData<byte>();
+        byte[] rgbaBytes = raw.ToArray();
+
+        var jpg = _compressor.Compress(
+            rgbaBytes, 0,
+            tex.width, tex.height,
+            TJPixelFormat.RGBA,
+            TJSubsamplingOption.Gray,
+            CompressionQuality,
+            TJFlags.FastDct | TJFlags.BottomUp
+        );
+
         data.format = "jpeg";
-        data.data = _cameraSensor.texture0.EncodeToJPG(CompressionQuality);
+        data.data = jpg;
 
         return base.GetMsg(ts);
     }

--- a/Runtime/Utils/UnitySensors/Scripts/Sensors/Camera/DepthCamera/DepthCameraSensor.cs
+++ b/Runtime/Utils/UnitySensors/Scripts/Sensors/Camera/DepthCamera/DepthCameraSensor.cs
@@ -12,7 +12,6 @@ using UnityEngine.UI;
 using UnitySensors.Data.PointCloud;
 using UnitySensors.Interface.Sensor;
 using UnitySensors.Utils.Noise;
-
 using Random = Unity.Mathematics.Random;
 
 namespace UnitySensors.Sensor.Camera
@@ -20,12 +19,9 @@ namespace UnitySensors.Sensor.Camera
     [AddComponentMenu("")]
     public class DepthCameraSensor : CameraSensor, ITextureInterface, IPointCloudInterface<PointXYZ>
     {
-        [SerializeField]
-        public float _minRange = 0.05f;
-        [SerializeField]
-        public float _maxRange = 100.0f;
-        [SerializeField]
-        public float _gaussianNoiseSigma = 0.0f;
+        [SerializeField] public float _minRange = 0.05f;
+        [SerializeField] public float _maxRange = 100.0f;
+        [SerializeField] public float _gaussianNoiseSigma = 0.0f;
 
 
         public UnityEngine.Camera _camera;
@@ -45,13 +41,31 @@ namespace UnitySensors.Sensor.Camera
         private PointCloud<PointXYZ> _pointCloud;
         private int _pointsNum;
 
-        public override UnityEngine.Camera m_camera { get => _camera; }
-        public Texture2D texture0 { get => _texture; }
-        public Texture2D texture1 { get => _texture; }
-        public PointCloud<PointXYZ> pointCloud { get => _pointCloud; }
-        public int pointsNum { get => _pointsNum; }
-        
-        
+        public override UnityEngine.Camera m_camera
+        {
+            get => _camera;
+        }
+
+        public Texture2D texture0
+        {
+            get => _texture;
+        }
+
+        public Texture2D texture1
+        {
+            get => _texture;
+        }
+
+        public PointCloud<PointXYZ> pointCloud
+        {
+            get => _pointCloud;
+        }
+
+        public int pointsNum
+        {
+            get => _pointsNum;
+        }
+
 
         public override void Init()
         {
@@ -59,10 +73,10 @@ namespace UnitySensors.Sensor.Camera
             _camera.nearClipPlane = _minRange;
             _camera.farClipPlane = _maxRange;
 
-            _rt = new RenderTexture(_resolution.x, _resolution.y, 32, RenderTextureFormat.ARGBFloat);
+            _rt = new RenderTexture(_resolution.x, _resolution.y, 32, RenderTextureFormat.ARGB32);
             _camera.targetTexture = _rt;
 
-            _texture = new Texture2D(_resolution.x, _resolution.y, TextureFormat.RGBAFloat, false);
+            _texture = new Texture2D(_resolution.x, _resolution.y, TextureFormat.ARGB32, false);
 
             float f = m_camera.farClipPlane;
             mat.SetFloat("_F", f);
@@ -73,7 +87,6 @@ namespace UnitySensors.Sensor.Camera
 
         private void SetupDirections()
         {
-            
             _pointsNum = _resolution.x * _resolution.y;
 
             _directions = new NativeArray<float3>(_pointsNum, Allocator.Persistent);
@@ -136,11 +149,11 @@ namespace UnitySensors.Sensor.Camera
                 jobHandle = _updateGaussianNoisesJob.Schedule(_pointsNum, 1);
             }
 
-            _textureToPointsJob.depthPixels = _texture.GetPixelData<Color>(0);
             _jobHandle = _textureToPointsJob.Schedule(_pointsNum, 1, jobHandle);
 
             JobHandle.ScheduleBatchedJobs();
             _jobHandle.Complete();
+                _textureToPointsJob.depthPixels = _texture.GetPixelData<Color32>(0);
 
 
             if (onSensorUpdated != null)
@@ -150,13 +163,14 @@ namespace UnitySensors.Sensor.Camera
         private bool LoadTexture()
         {
             bool result = false;
-            AsyncGPUReadback.Request(_rt, 0, request => {
+            AsyncGPUReadback.Request(_rt, 0, request =>
+            {
                 if (request.hasError)
                 {
                 }
                 else
                 {
-                    var data = request.GetData<Color>();
+                    var data = request.GetData<Color32>();
                     _texture.LoadRawTextureData(data);
                     _texture.Apply();
                     result = true;

--- a/Runtime/Utils/UnitySensors/Scripts/Sensors/Camera/DepthCamera/ITextureToPointsJob.cs
+++ b/Runtime/Utils/UnitySensors/Scripts/Sensors/Camera/DepthCamera/ITextureToPointsJob.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using UnityEngine;
-
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Jobs;
@@ -17,13 +16,10 @@ namespace UnitySensors.Sensor.Camera
         public float near;
         public float far;
 
-        [ReadOnly]
-        public NativeArray<float3> directions;
+        [ReadOnly] public NativeArray<float3> directions;
 
-        [ReadOnly]
-        public NativeArray<Color> depthPixels;
-        [ReadOnly]
-        public NativeArray<float> noises;
+        [ReadOnly] public NativeArray<Color32> depthPixels;
+        [ReadOnly] public NativeArray<float> noises;
 
         public NativeArray<PointXYZ> points;
 
@@ -31,7 +27,9 @@ namespace UnitySensors.Sensor.Camera
         {
             float distance = (1.0f - Mathf.Clamp01(depthPixels.AsReadOnly()[index].r)) * far;
             float distance_noised = distance + noises[index];
-            distance = (near < distance && distance < far && near < distance_noised && distance_noised < far) ? distance_noised : 0;
+            distance = (near < distance && distance < far && near < distance_noised && distance_noised < far)
+                ? distance_noised
+                : 0;
 
             PointXYZ point = new PointXYZ()
             {


### PR DESCRIPTION
Updates:
* Switched the Depth sensor to use the TurboJpeg lib for encoding like the regular camera.
* By default, the depth sensor would also output a point cloud with the image. Added a switch to turn it off.

Before (1920x1920 @ 30hz):

<img width="305" height="98" alt="image" src="https://github.com/user-attachments/assets/8a81210c-1562-458a-b0e0-fc1bd6ff06a7" />


After(1920x1920 @ 30hz pointcloud on)

<img width="346" height="99" alt="image" src="https://github.com/user-attachments/assets/2b10f241-2ccb-488f-ae1c-0e2adb0ee240" />



After (1920x1920 @ 30hz pointcloud off)

<img width="358" height="124" alt="image" src="https://github.com/user-attachments/assets/c4fcfe05-4535-42ab-af6c-ce6c94bfe1f7" />
