### PR TITLE
Lidar fixes

### DIFF
--- a/Runtime/Tx/RaycastLiDARTx.cs
+++ b/Runtime/Tx/RaycastLiDARTx.cs
@@ -89,12 +89,26 @@ namespace ProBridge.Tx.Sensor
 
         private ScanPattern ReduceScanPatternAngle(ScanPattern scanPattern, float minAzimuth, float maxAzimuth)
         {
-            if (Math.Abs(maxAzimuth - 360f) < ANGLE_TOLERANCE && minAzimuth == 0f) return scanPattern;
+            // Full-circle case
+            if (Math.Abs(maxAzimuth - 360f) < ANGLE_TOLERANCE && Mathf.Abs(minAzimuth) < ANGLE_TOLERANCE)
+                return scanPattern;
+
+            float NormalizeSignedAngle(float angle)
+            {
+                angle %= 360f;
+                if (angle > 180f) angle -= 360f;
+                if (angle <= -180f) angle += 360f;
+                return angle;
+            }
+
+            minAzimuth = NormalizeSignedAngle(minAzimuth);
+            maxAzimuth = NormalizeSignedAngle(maxAzimuth);
 
             var newScans = (from scan in scanPattern.scans
-                            let azimuth = Mathf.Atan2(-scan.x, -scan.z) * Mathf.Rad2Deg + 180f
-                            where azimuth >= minAzimuth && azimuth <= maxAzimuth
-                            select scan).ToList();
+                let azimuth = NormalizeSignedAngle(
+                    Mathf.Atan2(-scan.x, -scan.z) * Mathf.Rad2Deg + 180f)
+                where azimuth >= minAzimuth && azimuth <= maxAzimuth
+                select scan).ToList();
 
             var newScanPattern = Instantiate(scanPattern);
             newScanPattern.scans = newScans.ToArray();

--- a/Runtime/Utils/UnitySensors/Scripts/Sensors/LiDAR/RaycastLiDAR/IRaycastHitsToPointsJob.cs
+++ b/Runtime/Utils/UnitySensors/Scripts/Sensors/LiDAR/RaycastLiDAR/IRaycastHitsToPointsJob.cs
@@ -41,7 +41,7 @@ namespace UnitySensors.Sensor.LiDAR
             distance = (minRange < distance && distance < maxRange && minRange < distance_noised && distance_noised < maxRange) ? distance_noised : 0;
             PointXYZI point = new PointXYZI()
             {
-                position = directions[index + indexOffset] * distance,
+                position = math.normalize(directions[index + indexOffset]) * distance,
                 intensity = (distance != 0) ? maxIntensity * minRange_sqr / (distance * distance) : 0
             };
             points[index] = point;

--- a/Runtime/Utils/UnitySensors/Scripts/Sensors/LiDAR/RaycastLiDAR/IUpdateRaycastCommandsJob.cs
+++ b/Runtime/Utils/UnitySensors/Scripts/Sensors/LiDAR/RaycastLiDAR/IUpdateRaycastCommandsJob.cs
@@ -16,7 +16,7 @@ namespace UnitySensors.Sensor.LiDAR
         [ReadOnly]
         public Vector3 origin;
         [ReadOnly]
-        public Matrix4x4 localToWorldMatrix;
+        public quaternion rotation;
         [ReadOnly]
         public float maxRange;
         [ReadOnly, NativeDisableParallelForRestriction]
@@ -27,7 +27,8 @@ namespace UnitySensors.Sensor.LiDAR
 
         public void Execute(int index)
         {
-            raycastCommands[index] = new RaycastCommand(origin, localToWorldMatrix * (Vector3)directions[index + indexOffset], maxRange);
+            float3 worldDirection = math.normalize(math.mul(rotation, directions[index + indexOffset]));
+            raycastCommands[index] = new RaycastCommand(origin, (Vector3)worldDirection, maxRange);
         }
     }
 }

--- a/Runtime/Utils/UnitySensors/Scripts/Sensors/LiDAR/RaycastLiDAR/RaycastLiDARSensor.cs
+++ b/Runtime/Utils/UnitySensors/Scripts/Sensors/LiDAR/RaycastLiDAR/RaycastLiDARSensor.cs
@@ -60,7 +60,7 @@ namespace UnitySensors.Sensor.LiDAR
             _updateRaycastCommandsJob = new IUpdateRaycastCommandsJob()
             {
                 origin = _transform.position,
-                localToWorldMatrix = _transform.localToWorldMatrix,
+                rotation = _transform.rotation,
                 maxRange = maxRange,
                 directions = _directions,
                 indexOffset = 0,
@@ -91,7 +91,7 @@ namespace UnitySensors.Sensor.LiDAR
         public override void UpdateSensor()
         {
             _updateRaycastCommandsJob.origin = _transform.position;
-            _updateRaycastCommandsJob.localToWorldMatrix = _transform.localToWorldMatrix;
+            _updateRaycastCommandsJob.rotation = _transform.rotation;
 
             JobHandle updateRaycastCommandsJobHandle = _updateRaycastCommandsJob.Schedule(pointsNum, 1);
             JobHandle updateGaussianNoisesJobHandle = _updateGaussianNoisesJob.Schedule(pointsNum, 1, updateRaycastCommandsJobHandle);


### PR DESCRIPTION
1. Fix lidar azimuth cropping to allow for negative angles, allowing for a bigger range of angles.
2. Make lidar output independent of object scale.